### PR TITLE
Feature/refactor zaak ordering

### DIFF
--- a/src/openzaak/components/zaken/api/filters.py
+++ b/src/openzaak/components/zaken/api/filters.py
@@ -56,6 +56,12 @@ class ZaakFilter(FilterSet):
             mark_oas_difference("Haal details van inline resources direct op.")
         ),
     )
+    ordering = filters.OrderingFilter(
+        fields=("startdatum", "einddatum", "publicatiedatum", "archiefactiedatum",),
+        help_text=_(
+            mark_oas_difference("Het veld waarop de resultaten geordend worden.")
+        ),
+    )
 
     class Meta:
         model = Zaak

--- a/src/openzaak/components/zaken/api/viewsets.py
+++ b/src/openzaak/components/zaken/api/viewsets.py
@@ -36,7 +36,6 @@ from zgw_consumers.models import Service
 
 from openzaak.utils.api import delete_remote_oio
 from openzaak.utils.data_filtering import ListFilterByAuthorizationsMixin
-from openzaak.utils.filters import OrderingFilter
 
 from ..models import (
     KlantContact,
@@ -227,14 +226,8 @@ class ZaakViewSet(
     )
     serializer_class = ZaakSerializer
     search_input_serializer_class = ZaakZoekSerializer
-    filter_backends = (Backend, OrderingFilter)
+    filter_backends = (Backend,)
     filterset_class = ZaakFilter
-    ordering_fields = (
-        "startdatum",
-        "einddatum",
-        "publicatiedatum",
-        "archiefactiedatum",
-    )
     lookup_field = "uuid"
     pagination_class = PageNumberPagination
 

--- a/src/openzaak/components/zaken/openapi.yaml
+++ b/src/openzaak/components/zaken/openapi.yaml
@@ -1928,15 +1928,19 @@ paths:
           - zaakinformatieobjecten
       - name: ordering
         in: query
-        description: '***AFWIJKING:** Which field to use when ordering the results.'
+        description: '***AFWIJKING:** Het veld waarop de resultaten geordend worden.'
         required: false
         schema:
           type: string
           enum:
           - startdatum
+          - -startdatum
           - einddatum
+          - -einddatum
           - publicatiedatum
+          - -publicatiedatum
           - archiefactiedatum
+          - -archiefactiedatum
       - name: page
         in: query
         description: Een pagina binnen de gepagineerde set resultaten.
@@ -5914,9 +5918,37 @@ components:
           - zaakinformatieobjecten
         ordering:
           title: Ordering
-          description: '***AFWIJKING:** Which field to use when ordering the results.'
+          description: '***AFWIJKING:** Het veld waarop de resultaten geordend worden.
+
+
+            Uitleg bij mogelijke waarden:
+
+
+            * `startdatum` - Startdatum
+
+            * `-startdatum` - Startdatum (descending)
+
+            * `einddatum` - Einddatum
+
+            * `-einddatum` - Einddatum (descending)
+
+            * `publicatiedatum` - Publicatiedatum
+
+            * `-publicatiedatum` - Publicatiedatum (descending)
+
+            * `archiefactiedatum` - Archiefactiedatum
+
+            * `-archiefactiedatum` - Archiefactiedatum (descending)'
           type: string
-          minLength: 1
+          enum:
+          - startdatum
+          - -startdatum
+          - einddatum
+          - -einddatum
+          - publicatiedatum
+          - -publicatiedatum
+          - archiefactiedatum
+          - -archiefactiedatum
     Wijzigingen:
       type: object
       properties:

--- a/src/openzaak/components/zaken/swagger2.0.json
+++ b/src/openzaak/components/zaken/swagger2.0.json
@@ -2610,14 +2610,18 @@
                     {
                         "name": "ordering",
                         "in": "query",
-                        "description": "***AFWIJKING:** Which field to use when ordering the results.",
+                        "description": "***AFWIJKING:** Het veld waarop de resultaten geordend worden.",
                         "required": false,
                         "type": "string",
                         "enum": [
                             "startdatum",
+                            "-startdatum",
                             "einddatum",
+                            "-einddatum",
                             "publicatiedatum",
-                            "archiefactiedatum"
+                            "-publicatiedatum",
+                            "archiefactiedatum",
+                            "-archiefactiedatum"
                         ]
                     },
                     {
@@ -7193,9 +7197,18 @@
                 },
                 "ordering": {
                     "title": "Ordering",
-                    "description": "***AFWIJKING:** Which field to use when ordering the results.",
+                    "description": "***AFWIJKING:** Het veld waarop de resultaten geordend worden.\n\nUitleg bij mogelijke waarden:\n\n* `startdatum` - Startdatum\n* `-startdatum` - Startdatum (descending)\n* `einddatum` - Einddatum\n* `-einddatum` - Einddatum (descending)\n* `publicatiedatum` - Publicatiedatum\n* `-publicatiedatum` - Publicatiedatum (descending)\n* `archiefactiedatum` - Archiefactiedatum\n* `-archiefactiedatum` - Archiefactiedatum (descending)",
                     "type": "string",
-                    "minLength": 1
+                    "enum": [
+                        "startdatum",
+                        "-startdatum",
+                        "einddatum",
+                        "-einddatum",
+                        "publicatiedatum",
+                        "-publicatiedatum",
+                        "archiefactiedatum",
+                        "-archiefactiedatum"
+                    ]
                 }
             }
         },

--- a/src/openzaak/components/zaken/tests/test_zaken.py
+++ b/src/openzaak/components/zaken/tests/test_zaken.py
@@ -561,7 +561,33 @@ class ZakenTests(JWTAuthMixin, APITestCase):
         self.assertEqual(response_gte.data["results"][0]["startdatum"], "2019-03-01")
         self.assertEqual(response_lte.data["results"][0]["startdatum"], "2019-01-01")
 
-    def test_sort_datum(self):
+    def test_sort_datum_ascending(self):
+        sorting_params = [
+            "startdatum",
+            "einddatum",
+            "publicatiedatum",
+            "archiefactiedatum",
+        ]
+
+        for param in sorting_params:
+            with self.subTest(param=param):
+                Zaak.objects.all().delete()
+                ZaakFactory.create(**{param: "2019-01-01"}, zaaktype=self.zaaktype)
+                ZaakFactory.create(**{param: "2019-03-01"}, zaaktype=self.zaaktype)
+                ZaakFactory.create(**{param: "2019-02-01"}, zaaktype=self.zaaktype)
+                url = reverse("zaak-list")
+
+                response = self.client.get(url, {"ordering": param}, **ZAAK_READ_KWARGS)
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+                data = response.data["results"]
+
+                self.assertEqual(data[0][param], "2019-01-01")
+                self.assertEqual(data[1][param], "2019-02-01")
+                self.assertEqual(data[2][param], "2019-03-01")
+
+    def test_sort_datum_descending(self):
         sorting_params = [
             "startdatum",
             "einddatum",


### PR DESCRIPTION
`django_filters.OrderingFilter` does properly show the enum in the OAS without overriding anything