### PR TITLE
:arrow_up: Bump mozilla-django-oidc-db to 0.6.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -173,7 +173,7 @@ markdown==3.0.1
     # via -r requirements/base.in
 markupsafe==1.1.1
     # via jinja2
-mozilla-django-oidc-db==0.5.0
+mozilla-django-oidc-db==0.6.0
     # via -r requirements/base.in
 mozilla-django-oidc==1.2.4
     # via mozilla-django-oidc-db

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -250,7 +250,7 @@ markupsafe==1.1.1
     #   jinja2
 mccabe==0.6.1
     # via flake8
-mozilla-django-oidc-db==0.5.0
+mozilla-django-oidc-db==0.6.0
     # via -r requirements/base.txt
 mozilla-django-oidc==1.2.4
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -316,7 +316,7 @@ mccabe==0.6.1
     # via
     #   -r requirements/ci.txt
     #   flake8
-mozilla-django-oidc-db==0.5.0
+mozilla-django-oidc-db==0.6.0
     # via -r requirements/ci.txt
 mozilla-django-oidc==1.2.4
     # via


### PR DESCRIPTION
To fix an error that occurs on the OIDC form for users with readonly access

